### PR TITLE
fix: Unpausing stream at end of object

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,9 @@ module.exports = function(stream, options) {
 			stackTop[key] = val;
 		} else if (!stackTop) { // Pushing object out of bounds - assume top level scalar
 			if (settings.allowScalars) {
-				var resume;
-				if (settings.pause) resume = stream.pause();
+				if (settings.pause) stream.pause();
 				emitter.emit('bfjc', val);
-				if (settings.pause) resume();
+				if (settings.pause && stream.isPaused()) stream.resume();
 			}
 		} else {
 			stackTop.push(val);
@@ -47,14 +46,13 @@ module.exports = function(stream, options) {
 			}
 		})
 		.on(bfj.events.endObject, ()=> {
-			var resume;
 			if (stack.length == 1) {
-				if (settings.pause) resume = stream.pause();
+				if (settings.pause) stream.pause();
 				emitter.emit('bfjc', stack[0]);
 			}
 			stack.pop();
 			stackTop = stack[stack.length-1];
-			if (stack.length == 1 && settings.pause) resume();
+			if (settings.pause && stream.isPaused()) stream.resume();
 		})
 		.on(bfj.events.array, ()=> {
 			if (stackProp.length) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,9 @@
 var bfj = require('bfj');
 var bfjc = require('..');
-var expect = require('chai').expect;
+var chai = require('chai')
+var spies = require('chai-spies');
+chai.use(spies);
+var expect = chai.expect;
 var Readable = require('stream').Readable;
 
 var str2stream = (str) => {
@@ -55,6 +58,16 @@ describe('bfjc(data)', function() {
 
 	it('should have a return of matching original input', ()=> {
 		expect(results).to.deep.equal(data);
+	});
+
+	it('should emit end', done => {
+		const spyEnd = chai.spy();
+		bfjc(str2stream(JSON.stringify(data)))
+			.on(bfj.events.end, () => {
+				spyEnd();
+				expect(spyEnd).to.have.been.called.once;
+				done();
+			});
 	});
 
 });


### PR DESCRIPTION
Node: `v16.20.2`

`typeof resume` was reporting `'object'` rather than a `'function'`.

Checked `ReadStream` docs back to `v6` and couldn't see anything much different. Perhaps it once worked but broke with upstream changes. Source for `bfc` suggests streams didn't work exactly the same as they do now.

Using `ReadStream.isPaused()` and ReadStream.resume()`.